### PR TITLE
fixed tests for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The Project is divided in two main parts:
 - Public APIs
 - Internal APIs
 
-    Description here
 ## How to start
 
 Assuming that you have `go`, `docker` and `docker-compose` installed in your machine, run `docker-compose up -d` to spin up aerospike and localstack (for local S3).

--- a/internal/routes_test.go
+++ b/internal/routes_test.go
@@ -39,6 +39,7 @@ func TestMain(m *testing.M) {
 }
 
 func tearUp() {
+
 	gin.SetMode(gin.TestMode)
 
 	router = gin.Default()


### PR DESCRIPTION
Tests were passing because I was manually initializing the testing S3 bucket in Localstack as mentioned in the README.
For a new user, the tests were failing because the bucket was missing. I removed the dependency on the manual initialization of localstack S3 bucket and added a proper `tearUp()` function.