### PR TITLE
dont version root endpoints

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -22,12 +22,12 @@ func NewInternalAPI(middlewares ...gin.HandlerFunc) (*Internal, error) {
 		r.Use(m)
 	}
 
+	// Base path
+	r.GET("/", LongVersion)
+	r.GET("/healthz", Healthz)
+
 	// Internal API v1
 	v1 := r.Group("v1")
-
-	// Routes
-	v1.GET("/", LongVersion)
-
 	v1.POST("/streaming", CreateStreaming)
 	v1.PUT("/streaming", UpdateStreaming)
 	v1.DELETE("/streaming", DeleteStreaming)
@@ -54,9 +54,6 @@ func NewInternalAPI(middlewares ...gin.HandlerFunc) (*Internal, error) {
 	mm.GET("/all", GetAllModels)
 	mm.POST("/publish", PublishModel)
 	mm.POST("/stage", StageModel)
-
-	// Healthz
-	v1.GET("/healthz", Healthz)
 
 	// Docs
 	v1.Static("/docs", "docs/swagger-internal")

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestLongVersion(t *testing.T) {
-	router.GET("/v1/", LongVersion)
+	router.GET("/", LongVersion)
 
-	code, body, err := MockRequest(http.MethodGet, "/v1/", nil)
+	code, body, err := MockRequest(http.MethodGet, "/", nil)
 	if err != nil {
 		t.FailNow()
 	}

--- a/public/healthz_test.go
+++ b/public/healthz_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-	router.GET("/v1/healthz", Healthz)
+	router.GET("/healthz", Healthz)
 
-	code, body, err := MockRequest(http.MethodGet, "/v1/healthz", nil)
+	code, body, err := MockRequest(http.MethodGet, "/healthz", nil)
 	if err != nil {
 		t.FailNow()
 	}

--- a/public/public.go
+++ b/public/public.go
@@ -22,13 +22,13 @@ func NewPublicAPI(middlewares ...gin.HandlerFunc) (*Public, error) {
 		r.Use(m)
 	}
 
+	// Base path for health checks
+	r.GET("/", LongVersion)
+	r.GET("/healthz", Healthz)
+
 	// Public API v1
 	v1 := r.Group("v1")
-
-	// Routes
-	v1.GET("/", LongVersion)
 	v1.GET("/recommend", Recommend)
-	v1.GET("/healthz", Healthz)
 
 	// Docs
 	v1.Static("/docs", "docs/swagger-public")


### PR DESCRIPTION
Kubernetes deployments with the endpoint updates currently fail due to default healthchecks on the root path, which was no longer exposed after the changes in the api versioning branch. This PR is to revert changes to root and health check endpoints.