### PR TITLE
fix go mod 1.16 issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/api
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/api -mod=mod
 
 # final stage
 FROM alpine:3.13

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,7 @@
 FROM golang:1.16
 
 ENV GO111MODULE=on
+ENV GOFLAGS=-mod=mod
 
 WORKDIR /app
 
@@ -11,7 +12,5 @@ COPY go.mod .
 COPY go.sum .
 
 RUN go mod download
-
-RUN go mod tidy
 
 COPY . .


### PR DESCRIPTION
when upgrading to Go 1.16, we encountered the error in CI pipeline:
`pkg/cache/allegro.go:8:2: missing go.sum entry for module providing package github.com/allegro/bigcache (imported by github.com/rtlnl/phoenix/pkg/cache); to add:
go get github.com/rtlnl/phoenix/pkg/cache
pkg/db/redis.go:8:2: missing go.sum entry for module providing package github.com/go-redis/redis/v7 (imported by github.com/rtlnl/phoenix/pkg/db); to add:
go get github.com/rtlnl/phoenix/pkg/db
/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/logger.go:14:2: missing go.sum entry for module providing package github.com/mattn/go-isatty (imported by github.com/gin-gonic/gin); to add:
go get github.com/gin-gonic/gin@v1.7.2
/go/pkg/mod/github.com/prometheus/client_golang@v1.10.0/prometheus/internal/metric.go:19:2: missing go.sum entry for module providing package github.com/prometheus/client_model/go (imported by github.com/prometheus/client_golang/prometheus); to add:
go get github.com/prometheus/client_golang/prometheus@v1.10.0
/go/pkg/mod/github.com/spf13/viper@v1.7.1/viper.go:47:2: missing go.sum entry for module providing package github.com/subosito/gotenv (imported by github.com/spf13/viper); to add:
go get github.com/spf13/viper@v1.7.`

as suggested in this link: https://github.com/golang/go/issues/44129#issuecomment-854975677 the mod flag is added
